### PR TITLE
fix: Added outputs for resolver rules

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,14 +1,9 @@
-output "rr_ids" {
-  description = "Resolver rule IDs"
-  value       = try(aws_route53_resolver_rule.r.*.id, [])
-}
-
 output "resolver_rules" {
   value = {
     for rule in aws_route53_resolver_rule.r : rule.domain_name => {
-      name = rule.name
-      type = rule.rule_type
-      ttl  = rule.resolver_endpoint_id
+      name                 = rule.name
+      rule_type            = rule.rule_type
+      esolver_endpoint_id  = rule.resolver_endpoint_id
     }
   }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,4 @@
+output "rr_ids" {
+  description = "Resolver rule IDs"
+  value       = try(aws_route53_resolver_rule.r.id, null)
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,5 @@
 output "resolver_rules" {
+  description = "Resolver rules"
   value = {
     for rule in aws_route53_resolver_rule.r : rule.domain_name => {
       name                  = rule.name

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,9 +1,10 @@
 output "resolver_rules" {
   value = {
     for rule in aws_route53_resolver_rule.r : rule.domain_name => {
-      name                 = rule.name
-      rule_type            = rule.rule_type
-      esolver_endpoint_id  = rule.resolver_endpoint_id
+      name                  = rule.name
+      rule_type             = rule.rule_type
+      resolver_rule_id      = rule.id
+      resolver_endpoint_id  = rule.resolver_endpoint_id
     }
   }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -2,3 +2,13 @@ output "rr_ids" {
   description = "Resolver rule IDs"
   value       = try(aws_route53_resolver_rule.r.*.id, [])
 }
+
+output "resolver_rules" {
+  value = {
+    for rule in aws_route53_resolver_rule.r : rule.domain_name => {
+      name = rule.name
+      type = rule.rule_type
+      ttl  = rule.resolver_endpoint_id
+    }
+  }
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,4 @@
 output "rr_ids" {
   description = "Resolver rule IDs"
-  value       = try(aws_route53_resolver_rule.r.id, null)
+  value       = try(aws_route53_resolver_rule.r.*.id, null)
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,4 @@
 output "rr_ids" {
   description = "Resolver rule IDs"
-  value       = try(aws_route53_resolver_rule.r.*.id, null)
+  value       = try(aws_route53_resolver_rule.r.*.id, [])
 }


### PR DESCRIPTION
This is needed to reference objects provided by this module in other modules.