### PR TITLE
chore: Add release-please for automated Terraform module releases

### DIFF
--- a/.github/.release-please-config.json
+++ b/.github/.release-please-config.json
@@ -1,0 +1,47 @@
+{
+  "packages": {
+    ".": {
+      "release-type": "terraform-module",
+      "package-name": "terraform-aws-route53-resolver-rules",
+      "versioning": "always-bump-patch",
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true,
+      "include-v-in-tag": false,
+      "tag-format": "${version}",
+      "extra-files": [],
+      "changelog-path": "CHANGELOG.md",
+      "draft": false,
+      "prerelease": false
+    }
+  },
+  "release-search-depth": 10,
+  "include-component-in-tag": false,
+  "include-v-in-tag": false,
+  "tag-format": "${version}",
+  "pull-request-title-pattern": "chore${scope}: release${component} ${version}",
+  "changelog-types": [
+    {"type": "feat", "section": "Added", "hidden": false},
+    {"type": "fix", "section": "Fixed", "hidden": false},
+    {"type": "chore", "section": "Changed", "hidden": false},
+    {"type": "refactor", "section": "Refactored", "hidden": false},
+    {"type": "style", "section": "Styled", "hidden": false},
+    {"type": "security", "section": "Security", "hidden": false},
+    {"type": "docs", "section": "Documentation", "hidden": false},
+    {"type": "perf", "section": "Performance", "hidden": false}
+  ],
+  "changelog-sections": {
+    "header": "## ${version} (${date})",
+    "sections": {
+      "Added": "### Added",
+      "Changed": "### Changed",
+      "Fixed": "### Fixed",
+      "Documentation": "### Documentation",
+      "Security": "### Security",
+      "Performance": "### Performance"
+    }
+  },
+  "date-formats": {
+    "changelogDate": "(%B %d, %Y)"
+  },
+  "group-pull-request-title-pattern": "chore: release ${version}"
+} 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,19 @@
+name: release-please
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release_please.outputs.release_created }}
+    steps:
+      - uses: googleapis/release-please-action@v4
+        id: release_please
+        with:
+          release-type: terraform-module
+          token: ${{ secrets.GITHUB_TOKEN }}
+          config-file: .github/.release-please-config.json 


### PR DESCRIPTION
This pull request introduces a new release automation configuration for the repository. The most important changes include the addition of a configuration file for `release-please` and a GitHub Actions workflow to automate releases.

Release automation configuration:

* [`.github/.release-please-config.json`](diffhunk://#diff-654b5d1c6182210bb04674196ce31e01a13238f90a807f1a53c2e977687234c1R1-R47): Added a configuration file for `release-please` to define release types, versioning, changelog sections, and other settings.

GitHub Actions workflow:

* [`.github/workflows/release-please.yml`](diffhunk://#diff-2c84033033d49186c63e6adcd705f63b11ae6814cd76c152c9c486d389fbccf3R1-R19): Added a GitHub Actions workflow to automate the release process using `release-please`. This workflow triggers on pushes to the `master` branch and uses the configuration defined in `.release-please-config.json`.