### PR TITLE
feat: add Renovate for dependency management

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,13 @@
+{
+  "extends": ["config:base"],
+  "terraform": {
+    "ignoreDeps": ["hashicorp/terraform"]
+  },
+  "packageRules": [
+    {
+      "datasources": ["terraform-provider"],
+      "updateTypes": ["major"],
+      "enabled": false
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add renovate.json configuration for automated dependency management
- Configure Renovate to ignore Terraform core updates
- Disable major version updates for terraform providers to ensure stability
- Enable automated dependency updates for DNS/networking infrastructure components

## Configuration Details
- Extends base Renovate configuration for standard behavior
- Ignores `hashicorp/terraform` to prevent core Terraform updates
- Disables major version updates for terraform providers to maintain compatibility
- Follows baseline patterns established in terraform-aws-secrets-manager module

## Test Plan
- [x] Verify renovate.json syntax is valid JSON
- [x] Confirm configuration follows Terraform best practices for DNS/networking modules
- [x] Ensure compatibility with existing release-please workflow
- [ ] Monitor first Renovate run for proper dependency detection