### PR TITLE
fix: resolve "Cannot use a null value in for_each" when ips field is omitted

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -64,7 +64,7 @@ locals {
       domain_name = lookup(rule, "domain_name", null)
       ram_name    = lookup(rule, "ram_name", "r53-${lookup(rule, "domain_name")}")
       vpc_ids     = lookup(rule, "vpc_ids", [])
-      ips         = lookup(rule, "ips", null)
+      ips         = lookup(rule, "ips", [])
       principals  = lookup(rule, "principals", [])
     }
   }

--- a/variables.tf
+++ b/variables.tf
@@ -23,11 +23,11 @@ variable "rules" {
 
   validation {
     condition = alltrue([
-      for rule in var.rules : can(rule.ips) && alltrue([
+      for rule in var.rules : !can(rule.ips) || rule.ips == null || alltrue([
         for ip in rule.ips : can(regex("^((25[0-5]|(2[0-4]|1\\d|[1-9]?)\\d)\\.){3}(25[0-5]|(2[0-4]|1\\d|[1-9]?)\\d)(:[1-9]\\d{0,4}|:6553[0-5]|:655[0-2]\\d|:65[0-4]\\d{2}|:6[0-4]\\d{3})?$", ip)) || can(regex("^([0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}$|^::1$|^::$|^([0-9a-fA-F]{1,4}:)*::([0-9a-fA-F]{1,4}:)*[0-9a-fA-F]{1,4}$", ip))
       ])
     ])
-    error_message = "Each IP in the ips list must be a valid IPv4 address (optionally with port 1-65535) or IPv6 address."
+    error_message = "When provided, each IP in the ips list must be a valid IPv4 address (optionally with port 1-65535) or IPv6 address."
   }
 
   validation {


### PR DESCRIPTION
Fixes the issue where users encountered "Cannot use a null value in for_each" error when omitting the `ips` field from resolver rules.

## Changes
- Change default value for missing ips field from null to [] in locals
- Update validation to make ips field truly optional
- Allow resolver rules without target IP specifications
- Maintain backward compatibility with existing configurations

## Testing
Users can now create resolver rules without the `ips` field, which matches AWS Route53 resolver rule behavior where target_ip blocks are optional.

Fixes #11

Generated with [Claude Code](https://claude.ai/code)