### PR TITLE
feat: add Claude dispatch workflow for repository events

### DIFF
--- a/.github/workflows/claude-dispatch.yml
+++ b/.github/workflows/claude-dispatch.yml
@@ -1,0 +1,50 @@
+# IMPORTANT: Do not move this file in your repo! Make sure it's located at .github/workflows/claude-dispatch.yml
+
+name: Claude Code Dispatch
+
+# IMPORTANT: Do not modify this `on` section!
+
+on:
+  repository_dispatch:
+    types: [claude-dispatch]
+
+jobs:
+  claude-dispatch:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      # - name: Preliminary Setup
+      #   run: |
+      #     echo "Setting up environment..."
+      #     # Add any preliminary setup commands here to setup Claude's dev environment
+      #     # e.g., npm install, etc.
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@eap
+        with:
+          mode: 'remote-agent'
+          # Optional: Specify an API key, otherwise we'll use your Claude account automatically
+          # anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+
+          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
+          # model: "claude-opus-4-20250514"
+
+          # Optional: Allow Claude to run specific commands
+          # allowed_tools: |
+          #   Bash(npm run lint)
+          #   Bash(npm run test)
+          #   Bash(npm run build)
+
+          # Optional: Custom environment variables for Claude
+          # claude_env: |
+          #   NODE_ENV: test


### PR DESCRIPTION
## Summary
- Add claude-dispatch.yml workflow for repository_dispatch events
- Enables programmatic Claude Code task execution via GitHub API
- Complements existing comment-based Claude integration (@claude triggers)

## Features
- Triggered by repository_dispatch events with type 'claude'
- Uses Anthropic's Claude Code Action (beta)
- Configurable model selection (defaults to Claude Sonnet 4)
- Support for custom instructions and allowed tools
- Write permissions for contents, pull-requests, and issues

## Test plan
- [ ] Verify workflow file syntax is valid
- [ ] Test dispatch trigger via GitHub API (once merged)
- [ ] Confirm it works alongside existing claude.yml workflow